### PR TITLE
Feat: ação de jogar uma carta

### DIFF
--- a/src/main/java/br/ufrn/imd/cambio_imd/commands/CallCutCommand.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/commands/CallCutCommand.java
@@ -1,0 +1,34 @@
+package br.ufrn.imd.cambio_imd.commands;
+
+import br.ufrn.imd.cambio_imd.dao.GameContext;
+import br.ufrn.imd.cambio_imd.models.cards.DiscardPile;
+import br.ufrn.imd.cambio_imd.models.players.Player;
+import br.ufrn.imd.cambio_imd.models.players.Players;
+import java.util.Iterator;
+
+public class CallCutCommand implements ICommand {
+    private int playerId;
+
+    public CallCutCommand(int playerId){
+        this.playerId = playerId;
+    }
+
+    @Override
+    public void execute(){
+        // Aqui estamos apenas pegando o jogador para fazer sua incrível jogada e o deixar disponível para o corte.
+        GameContext context = GameContext.getInstance(); //< Pegando o contexto do jogo
+        
+        DiscardPile pile = context.getDiscardPile(); //< Pegando a pilha de descarte
+        Players players = context.getPlayers(); //< Pegando os jogadores (estranho...)
+        Player currentPlayer = players.findById(playerId).orElseThrow(() -> new IllegalArgumentException("Player not found")); //< Pegando o jogador 
+
+        if(currentPlayer.isProhibitedCut()){
+            System.out.println("Jogador não pode cortar!");
+            // TODO: Ações para continuar o corte sem o jogador
+        } else {
+            context.setCurrentPlayerToCut(currentPlayer); //< Setando o jogador atual para cortar
+        }
+    }
+    
+
+}

--- a/src/main/java/br/ufrn/imd/cambio_imd/commands/CreatePlayersCommand.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/commands/CreatePlayersCommand.java
@@ -1,6 +1,7 @@
 package br.ufrn.imd.cambio_imd.commands;
 
 import br.ufrn.imd.cambio_imd.dao.GameContext;
+import br.ufrn.imd.cambio_imd.enums.PlayerType;
 import br.ufrn.imd.cambio_imd.models.players.Player;
 import br.ufrn.imd.cambio_imd.models.players.Players;
 
@@ -12,8 +13,8 @@ public class CreatePlayersCommand implements ICommand {
         GameContext context = GameContext.getInstance();
 
         var players = new Players();
-        players.addPlayer(new Player("Jogador"));
-        players.addPlayer(new Player("Bot 1"));
+        players.addPlayer(new Player("Jogador", PlayerType.HUMAN));
+        players.addPlayer(new Player("Bot 1", PlayerType.ROBOT));
 
         context.setPlayers(players);
     }

--- a/src/main/java/br/ufrn/imd/cambio_imd/commands/CutCommand.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/commands/CutCommand.java
@@ -1,0 +1,40 @@
+package br.ufrn.imd.cambio_imd.commands;
+
+import br.ufrn.imd.cambio_imd.dao.GameContext;
+import br.ufrn.imd.cambio_imd.models.cards.DiscardPile;
+import br.ufrn.imd.cambio_imd.models.players.Player;
+import br.ufrn.imd.cambio_imd.models.players.Players;
+import java.util.Stack;
+import br.ufrn.imd.cambio_imd.models.cards.Card;
+
+public class CutCommand implements ICommand {
+
+    @Override
+    public void execute(){
+        // Carregando objetos para avaliação
+        GameContext context = GameContext.getInstance();
+        Players players = context.getPlayers();
+        Player currentPlayer = players.findById(context.getLastPlayerToPlayId()).orElse(null);
+        DiscardPile pile = context.getDiscardPile();
+
+        // Acessando a carta do topo e a carta abaixo da do topo
+        Stack<Card> cards = pile.getCards();
+
+        if (cards.size() < 2) {
+            throw new IllegalStateException("Not enough cards in the pile!");
+        }
+        Card topCard = cards.peek(); //< Carta no topo da pilha
+        Card secondCard = cards.get(cards.size() - 2); //< Carta no índice abaixo do topo
+
+        // Verificando as possíveis punições ou não para o jogador:
+        // Aqui estamos partindo do pressuposto que, ao chamar 
+        if(!topCard.equals(secondCard)){
+            if(currentPlayer.madeWrongCut()){
+                currentPlayer.setProhibitedCut(true);
+            } else {
+                currentPlayer.setWrongCut(true);
+            }
+        }
+    }
+}
+

--- a/src/main/java/br/ufrn/imd/cambio_imd/commands/PlayerDiscardCardOnPileCommand.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/commands/PlayerDiscardCardOnPileCommand.java
@@ -10,10 +10,10 @@ public class PlayerDiscardCardOnPileCommand implements ICommand {
     private DiscardPile pile;
     private int cardIndex;
 
-    public PlayerDiscardCardOnPileCommand(Player player, DiscardPile pile) {
+    public PlayerDiscardCardOnPileCommand(Player player, DiscardPile pile, int cardIndex) {
         this.player = player;
         this.pile = pile;
-        this.cardIndex = player.getCardIndex();
+        this.cardIndex = cardIndex;// player.getCardIndex();
     }
 
     @Override

--- a/src/main/java/br/ufrn/imd/cambio_imd/commands/PlayerDiscardCardOnPileCommand.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/commands/PlayerDiscardCardOnPileCommand.java
@@ -1,5 +1,6 @@
 package br.ufrn.imd.cambio_imd.commands;
 
+import br.ufrn.imd.cambio_imd.dao.GameContext;
 import br.ufrn.imd.cambio_imd.models.cards.Card;
 import br.ufrn.imd.cambio_imd.models.cards.DiscardPile;
 import br.ufrn.imd.cambio_imd.models.players.Player;
@@ -9,18 +10,20 @@ public class PlayerDiscardCardOnPileCommand implements ICommand {
     private DiscardPile pile;
     private int cardIndex;
 
-    public PlayerDiscardCardOnPileCommand(Player player, DiscardPile pile, int cardIndex) {
+    public PlayerDiscardCardOnPileCommand(Player player, DiscardPile pile) {
         this.player = player;
         this.pile = pile;
-        this.cardIndex = cardIndex;
+        this.cardIndex = player.getCardIndex();
     }
 
     @Override
     public void execute(){
        // Pegar carta selecionada
         Card selectedCard = player.removeCard(cardIndex);
-
         // Inserir na pilha de descarte
         pile.addCard(selectedCard);
+        
+        GameContext context = GameContext.getInstance();
+        context.setLastPlayerToPlayId(player.getId());
     }
 }

--- a/src/main/java/br/ufrn/imd/cambio_imd/commands/PlayerDrawCardFromPileCommand.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/commands/PlayerDrawCardFromPileCommand.java
@@ -7,25 +7,16 @@ import br.ufrn.imd.cambio_imd.models.players.Player;
 public class PlayerDrawCardFromPileCommand implements ICommand {
     private Player player;
     private DrawPile pile;
-    private int cardIndex;
 
-    public PlayerDrawCardFromPileCommand(Player player, DrawPile pile, int cardIndex) {
+    public PlayerDrawCardFromPileCommand(Player player, DrawPile pile) {
         this.player = player;
         this.pile = pile;
-        this.cardIndex = cardIndex;
     }
 
     @Override
     public void execute() {
-        // Jogador descarta uma carta
-        Card discardedCard = player.removeCard(cardIndex);
-
         // Remove a primeira carta da pilha de descarte
         Card newCard = pile.removeTopCard();
-
-        // Adiciona a carta descartada na pilha e randomiza
-        pile.addCard(discardedCard);
-        pile.shuffle();
 
         // Adiciona a carta da pilha na mão do jogador
         player.addCard(newCard);

--- a/src/main/java/br/ufrn/imd/cambio_imd/controllers/GameController.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/controllers/GameController.java
@@ -2,18 +2,21 @@ package br.ufrn.imd.cambio_imd.controllers;
 
 import br.ufrn.imd.cambio_imd.exceptions.UnitializedGameException;
 import br.ufrn.imd.cambio_imd.models.cards.Card;
-import br.ufrn.imd.cambio_imd.models.players.Player;
 import br.ufrn.imd.cambio_imd.utility.CardAssetMapper;
+import javafx.event.EventHandler;
 import javafx.fxml.FXML;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Stack;
 
 /**
@@ -32,6 +35,22 @@ public class GameController extends ControllerBase {
     @FXML
     private TextArea messageBox;
 
+    private Button playBtn = new Button();
+    private Button swapBtn = new Button();
+    private HBox optionsBox;
+
+    @FXML
+    protected void initialize() {
+        playBtn.setText("Jogar");
+        playBtn.setOnMouseClicked(click -> handlePlayBtnClick());
+        swapBtn.setText("Trocar");
+        swapBtn.setOnMouseClicked(click -> handleSwapBtnClick());
+        optionsBox = new HBox(5, playBtn, swapBtn); // Espaçamento de 5px
+        optionsBox.setAlignment(Pos.CENTER);
+        optionsBox.setStyle("-fx-background-color: rgba(0, 0, 0, 0.8); -fx-padding: 5px; -fx-border-radius: 5px;");
+        optionsBox.setTranslateY(-50);
+    }
+
 
     public void render() {
         try {
@@ -44,6 +63,34 @@ public class GameController extends ControllerBase {
         }
     }
 
+    @FXML
+    protected void handleCardClick(MouseEvent event) {
+        System.out.println("Clickou!!");
+        int cardIndex = uiManager.getClickedCard();
+
+        if (playerHandGridPane.getChildren().contains(optionsBox))
+            playerHandGridPane.getChildren().remove(optionsBox);
+
+        Node node = playerHandGridPane.getChildren().get(cardIndex);
+        int col = GridPane.getColumnIndex(node);
+        int row = GridPane.getRowIndex(node);
+        playerHandGridPane.add(optionsBox, col, row);
+
+        // Remove caixa ao clicar fora
+        playerHandGridPane.setOnMouseClicked(click -> {
+            if (click.getSource() != optionsBox){
+                playerHandGridPane.getChildren().remove(optionsBox);
+            }
+        });
+    }
+
+    protected void handlePlayBtnClick() {
+        System.out.println("Helloooo play");
+    }
+
+    protected void handleSwapBtnClick() {
+        System.out.println("Helloooo swaaaap");
+    }
 
     private void renderPlayerHand() {
         /**
@@ -68,6 +115,13 @@ public class GameController extends ControllerBase {
             cardImageView.setFitWidth(uiManager.getCardWidth());
             cardImageView.setPreserveRatio(true);
             cardImageView.setPickOnBounds(true);
+
+            int index = i; // Precisa disso para não dar erro no parametro abaixo
+            // Verificar porque somente a primeira carta que eu clico exibe a seleção de opções e as outras não..
+            cardImageView.setOnMouseClicked(mouseEvent -> {
+                uiManager.setClickedCard(index);
+                handleCardClick(mouseEvent);
+            });
 
             Image cardImg = CardAssetMapper.getBackCardAsset();
             cardImageView.setImage(cardImg);

--- a/src/main/java/br/ufrn/imd/cambio_imd/controllers/GameController.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/controllers/GameController.java
@@ -1,9 +1,10 @@
 package br.ufrn.imd.cambio_imd.controllers;
 
+import br.ufrn.imd.cambio_imd.enums.TransitionType;
 import br.ufrn.imd.cambio_imd.exceptions.UnitializedGameException;
 import br.ufrn.imd.cambio_imd.models.cards.Card;
 import br.ufrn.imd.cambio_imd.utility.CardAssetMapper;
-import javafx.event.EventHandler;
+import javafx.animation.FadeTransition;
 import javafx.fxml.FXML;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
@@ -14,8 +15,8 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.GridPane;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import javafx.util.Duration;
 
 import java.util.Stack;
 
@@ -35,27 +36,49 @@ public class GameController extends ControllerBase {
     @FXML
     private TextArea messageBox;
 
-    private Button playBtn = new Button();
-    private Button swapBtn = new Button();
-    private HBox optionsBox;
+    private final Button playBtn = new Button();
+    private final Button swapBtn = new Button();
+    private VBox optionsBox;
 
     @FXML
     protected void initialize() {
         playBtn.setText("Jogar");
         playBtn.setOnMouseClicked(click -> handlePlayBtnClick());
+        playBtn.setMinWidth(50);
         swapBtn.setText("Trocar");
         swapBtn.setOnMouseClicked(click -> handleSwapBtnClick());
-        optionsBox = new HBox(5, playBtn, swapBtn); // Espaçamento de 5px
+        swapBtn.setMinWidth(50);
+
+        optionsBox = new VBox(5, playBtn, swapBtn);
         optionsBox.setAlignment(Pos.CENTER);
-        optionsBox.setStyle("-fx-background-color: rgba(0, 0, 0, 0.8); -fx-padding: 5px; -fx-border-radius: 5px;");
-        optionsBox.setTranslateY(-50);
+        optionsBox.setStyle("""
+                -fx-background-color: rgba(50, 50, 50, 0.9);
+                -fx-border-color: white;
+                -fx-border-width: 1px;
+                -fx-border-radius: 5px;
+                -fx-background-radius: 5px;
+                -fx-padding: 10px;
+                -fx-margin-bottom: 10px;
+                -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.5), 5, 0, 0, 1);
+               """);
+
+        // Registra ação de fechar a janela de opções caso clique fora
+        playerHandGridPane.addEventFilter(MouseEvent.MOUSE_CLICKED, click -> {
+            Node source = (Node) click.getTarget();
+            boolean clickedOutsideCard = playerHandGridPane.getChildren().stream()
+                    .noneMatch(child -> child == source);
+
+            if (clickedOutsideCard) {
+                applyTransition(optionsBox, Duration.millis(300), TransitionType.FADE_OUT, () -> {
+                    playerHandGridPane.getChildren().remove(optionsBox);
+                });
+            }
+        });
     }
 
 
     public void render() {
         try {
-            // playerTurnLabel.setText(uiManager.getPlayerLabelText());
-            // drawPileCountLabel.setText(uiManager.getDrawPileCountText());
             print("Jogo iniciado");
             renderPlayerHand();
         } catch (UnitializedGameException ex) {
@@ -74,14 +97,11 @@ public class GameController extends ControllerBase {
         Node node = playerHandGridPane.getChildren().get(cardIndex);
         int col = GridPane.getColumnIndex(node);
         int row = GridPane.getRowIndex(node);
-        playerHandGridPane.add(optionsBox, col, row);
+        // Se estiver na 1ª linha aparece em cima da carta, senão, aparece abaixo.
+        optionsBox.setTranslateY(row == 0 ? -50 : 50);
+        applyTransition(optionsBox, Duration.millis(300), TransitionType.FADE_IN);
 
-        // Remove caixa ao clicar fora
-        playerHandGridPane.setOnMouseClicked(click -> {
-            if (click.getSource() != optionsBox){
-                playerHandGridPane.getChildren().remove(optionsBox);
-            }
-        });
+        playerHandGridPane.add(optionsBox, col, row);
     }
 
     protected void handlePlayBtnClick() {
@@ -105,8 +125,7 @@ public class GameController extends ControllerBase {
         final int MAX_COLUMN = 5;
         int correctRow = 0, correctColumn = 0;
 
-        playerHandGridPane.getChildren().clear();
-        // Não é pro controller acessar diretamente os dados do jogo, logo, pedimos ao manager a informação
+        playerHandGridPane.getChildren().clear(); // Limpa as cartas anteriores
         Stack<Card> playerHand = gameManager.getCurrentPlayerCards();
 
         for (int i = 0; i < playerHand.size(); i++) {
@@ -117,7 +136,6 @@ public class GameController extends ControllerBase {
             cardImageView.setPickOnBounds(true);
 
             int index = i; // Precisa disso para não dar erro no parametro abaixo
-            // Verificar porque somente a primeira carta que eu clico exibe a seleção de opções e as outras não..
             cardImageView.setOnMouseClicked(mouseEvent -> {
                 uiManager.setClickedCard(index);
                 handleCardClick(mouseEvent);
@@ -137,5 +155,47 @@ public class GameController extends ControllerBase {
     private void print(String msg) {
         String instant = uiManager.getFormattedInstant();
         messageBox.appendText("[" + instant + "]: " + msg + "\n");
+    }
+
+    /**
+     * Aplica uma transição do tipo <code>FadeTransition</code> em um elemento.
+     * @param element
+     * @param time
+     * @param type
+     */
+    private void applyTransition(Node element, Duration time, TransitionType type) {
+        applyTransition(element, time, type, null);
+    }
+
+    /**
+     * Aplica uma transição do tipo <code>FadeTransition</code> em um elemento.
+     * @param element
+     * @param time
+     * @param type
+     * @param onFinish
+     */
+    private void applyTransition(Node element, Duration time, TransitionType type,
+                                 Runnable onFinish) {
+        FadeTransition transition = new FadeTransition(time, element);
+        switch (type) {
+            case FADE_IN -> {
+                transition.setFromValue(0.0);
+                transition.setToValue(1.0);
+                break;
+            }
+            case FADE_OUT -> {
+                transition.setFromValue(1.0);
+                transition.setToValue(0.0);
+                break;
+            }
+            default -> {
+                break;
+            }
+        }
+
+        if (onFinish != null) {
+            transition.setOnFinished(event -> onFinish.run());
+        }
+        transition.play();
     }
 }

--- a/src/main/java/br/ufrn/imd/cambio_imd/controllers/GameController.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/controllers/GameController.java
@@ -4,6 +4,7 @@ import br.ufrn.imd.cambio_imd.enums.TransitionType;
 import br.ufrn.imd.cambio_imd.exceptions.UnitializedGameException;
 import br.ufrn.imd.cambio_imd.models.cards.Card;
 import br.ufrn.imd.cambio_imd.observers.IGameAnimationObserver;
+import br.ufrn.imd.cambio_imd.observers.IGameStateObserver;
 import br.ufrn.imd.cambio_imd.utility.CardAssetMapper;
 import javafx.animation.FadeTransition;
 import javafx.fxml.FXML;
@@ -55,7 +56,7 @@ public class GameController extends ControllerBase {
     protected void initialize() {
         // FIXME: documentar bem essa inicialização
         // Registrando observadores por classes anônimas
-        gameManager.addObserver(new IGameAnimationObserver() {
+        gameManager.addAnimationObserver(new IGameAnimationObserver() {
             @Override
             public void onCardDrawn() {
                 animateCardDrawn();
@@ -66,6 +67,17 @@ public class GameController extends ControllerBase {
                 animateCardDiscarded();
             }
         });
+
+        /*
+        gameManager.addStateObserver(() -> new IGameStateObserver() {
+            @Override
+            public void onStart() {
+                System.out.println("Mudou pra jogo");
+                render();
+            }
+        });
+        */
+        gameManager.addStateObserver(this::render);
 
         playBtn.setText("Jogar");
         playBtn.setOnMouseClicked(click -> handlePlayBtnClick());

--- a/src/main/java/br/ufrn/imd/cambio_imd/controllers/MenuController.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/controllers/MenuController.java
@@ -3,6 +3,7 @@ package br.ufrn.imd.cambio_imd.controllers;
 import br.ufrn.imd.cambio_imd.enums.Screen;
 import br.ufrn.imd.cambio_imd.managers.GameManager;
 import br.ufrn.imd.cambio_imd.managers.ScreenManager;
+import br.ufrn.imd.cambio_imd.observers.IGameStateObserver;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;

--- a/src/main/java/br/ufrn/imd/cambio_imd/dao/GameContext.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/dao/GameContext.java
@@ -1,6 +1,6 @@
 package br.ufrn.imd.cambio_imd.dao;
 
-import br.ufrn.imd.cambio_imd.exceptions.UnitializedGameException;
+import br.ufrn.imd.cambio_imd.exceptions.UninitializedGameException;
 import br.ufrn.imd.cambio_imd.models.cards.DiscardPile;
 import br.ufrn.imd.cambio_imd.models.cards.DrawPile;
 import br.ufrn.imd.cambio_imd.models.players.Player;
@@ -9,32 +9,31 @@ import br.ufrn.imd.cambio_imd.models.players.Players;
 public class GameContext {
 
     /**
-     *
+     * Informações sobre os players
+     * 
      */
-    private Players players = new Players();
+    private Players players = new Players(); //< Lista de jogadores
 
-    private int currentPlayerIndex = 0;
+    // Jogadas a serem realizdas
+    private int currentPlayerIndex = 0; //< Atual jogador na ordem cronológica original do jogo (Acesso de avanço de ordem de jogo, por isso um inteiro)
+    private Player currentPlayerToCut = null; //< Atual jogador a fazer o seu corte, fora da ordem cronológica (Acesso direto, sem ordem, por isso um objeto)
+    private int lastPlayerToPlayId = 0; //< Último jogador a realizar uma jogada, seja ela de corte, seja ela de descarte padrão.
+    
+    // Resultado de jogo
+    private Player winner = null; //< Jogador vencedor
 
 
     /**
-     *
+     * Informações sobre as cartas
      */
-    private DrawPile drawPile = new DrawPile();
 
-    /**
-     *
-     */
-    private DiscardPile discardPile = new DiscardPile();
+    // Objetos de uso de fluxo de jogo
+    private DrawPile drawPile = new DrawPile(); //< Pilha de reposição, onde os jogadores puxam as cartas
+    private DiscardPile discardPile = new DiscardPile(); //< Pilha central, onde os jogadores jogam as cartas
 
-    /**
-     * talvez melhorar esses nomes
-     */
+    // Informações sobre a mão dos jogadores
     private int cardsPerHandLimit = 0; //< Quantas cartas a mão de cada jogador terá
     private int revealedCardsLimit = 0; //< Quantas cartas os jogadores poderão ver inicialmente
-
-    /*
-     */
-    private Player winner = null;
 
     private static GameContext instance = null;
 
@@ -46,6 +45,17 @@ public class GameContext {
             instance = new GameContext();
 
         return instance;
+    }
+
+    /*
+     * Métodos relacionados aos jogadores
+     */
+    public Players getPlayers() {
+        return players;
+    }
+
+    public void setPlayers(Players players) {
+        this.players = players;
     }
 
     public Player getCurrentPlayer() {
@@ -60,14 +70,37 @@ public class GameContext {
         return playersArray[currentPlayerIndex];
     }
 
-    public Players getPlayers() {
-        return players;
+    public Player getCurrentPlayerToCut() {
+        return currentPlayerToCut;
     }
 
-    public void setPlayers(Players players) {
-        this.players = players;
+    public void setCurrentPlayerToCut(Player currentPlayerToCut) {
+        this.currentPlayerToCut = currentPlayerToCut;
     }
 
+    public int getCurrentPlayerIndex() {
+        return currentPlayerIndex;
+    }
+
+    public void setCurrentPlayerIndex(int currentPlayerIndex) {
+        this.currentPlayerIndex = currentPlayerIndex;
+    }
+
+    public int getLastPlayerToPlayId() {
+        return lastPlayerToPlayId;
+    }
+
+    public void setLastPlayerToPlayId(int lastPlayerToPlayId) {
+        this.lastPlayerToPlayId = lastPlayerToPlayId;
+    }
+
+    public void setWinner(Player winner) {
+        this.winner = winner;
+    }
+
+    /*
+     * Métodos relacionados ao gerenciamento de pilhas
+     */
     public DrawPile getDrawPile() {
         return drawPile;
     }
@@ -80,10 +113,17 @@ public class GameContext {
         return this.drawPile.getAmount();
     }
 
+    public DiscardPile getDiscardPile() {
+        return discardPile;
+    }
+
     public void setDiscardPile(DiscardPile discardPile) {
         this.discardPile = discardPile;
     }
 
+    /*
+     * Métodos relacionados às configurações de jogo
+     */
     public int getCardsPerHandLimit() {
         return cardsPerHandLimit;
     }
@@ -94,9 +134,5 @@ public class GameContext {
 
     public void setRevealedCardsLimit(int revealedCardsLimit) {
         this.revealedCardsLimit = revealedCardsLimit;
-    }
-
-    public void setWinner(Player winner) {
-        this.winner = winner;
     }
 }

--- a/src/main/java/br/ufrn/imd/cambio_imd/enums/PlayerType.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/enums/PlayerType.java
@@ -1,0 +1,6 @@
+package br.ufrn.imd.cambio_imd.enums;
+
+public enum PlayerType {
+    HUMAN,
+    ROBOT
+}

--- a/src/main/java/br/ufrn/imd/cambio_imd/enums/TransitionType.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/enums/TransitionType.java
@@ -1,0 +1,6 @@
+package br.ufrn.imd.cambio_imd.enums;
+
+public enum TransitionType {
+    FADE_IN,
+    FADE_OUT
+}

--- a/src/main/java/br/ufrn/imd/cambio_imd/managers/GameUIManager.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/managers/GameUIManager.java
@@ -13,6 +13,7 @@ import java.util.Stack;
 public class GameUIManager {
     private double cardWidth;
     private double cardHeight;
+    private int clickedCard;
     private static GameUIManager instance;
     private GameContext context = GameContext.getInstance();
 
@@ -72,4 +73,11 @@ public class GameUIManager {
         return formattedTime;
     }
 
+    public int getClickedCard() {
+        return clickedCard;
+    }
+
+    public void setClickedCard(int clickedCard) {
+        this.clickedCard = clickedCard;
+    }
 }

--- a/src/main/java/br/ufrn/imd/cambio_imd/managers/GameUIManager.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/managers/GameUIManager.java
@@ -1,6 +1,8 @@
 package br.ufrn.imd.cambio_imd.managers;
 
 import br.ufrn.imd.cambio_imd.models.cards.Card;
+import javafx.geometry.Point2D;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.control.Label;
 import br.ufrn.imd.cambio_imd.dao.GameContext;
 import br.ufrn.imd.cambio_imd.models.players.Player;
@@ -14,6 +16,7 @@ public class GameUIManager {
     private double cardWidth;
     private double cardHeight;
     private int clickedCard;
+    private Point2D discardPaneCoords = new Point2D(175, 12);
     private static GameUIManager instance;
     private GameContext context = GameContext.getInstance();
 
@@ -22,6 +25,14 @@ public class GameUIManager {
 
     public double getCardWidth() {
         return cardWidth;
+    }
+
+    public Point2D getDiscardPaneCoords() {
+        return discardPaneCoords;
+    }
+
+    public void setDiscardPaneCoords(double x, double y) {
+        discardPaneCoords = new Point2D(x, y);
     }
 
     public void setCardWidth(double cardWidth) {

--- a/src/main/java/br/ufrn/imd/cambio_imd/models/players/Player.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/models/players/Player.java
@@ -1,5 +1,6 @@
 package br.ufrn.imd.cambio_imd.models.players;
 
+import br.ufrn.imd.cambio_imd.enums.PlayerType;
 import br.ufrn.imd.cambio_imd.exceptions.EmptyCardException;
 import br.ufrn.imd.cambio_imd.models.Entity;
 import br.ufrn.imd.cambio_imd.models.cards.Card;
@@ -9,6 +10,7 @@ public class Player extends Entity {
     private boolean wrongCut = false;
     private boolean prohibitedCut = false;
     private CardHand cardHand = new CardHand();
+    private PlayerType type = PlayerType.ROBOT;
 
     private int cardIndex = -1;
 
@@ -16,23 +18,26 @@ public class Player extends Entity {
         super();
     }
 
-    public Player(String name) {
+    public Player(String name, PlayerType type) {
         super();
         this.name = name;
+        this.type = type;
     }
 
-    public Player(String name, boolean wrongCut, CardHand cardHand) {
+    public Player(String name, boolean wrongCut, CardHand cardHand, PlayerType type) {
         super();
         this.name = name;
         this.wrongCut = wrongCut;
         this.cardHand = cardHand;
+        this.type = type;
     }
 
-    public Player(int id, String name, boolean wrongCut, CardHand cardHand) {
+    public Player(int id, String name, boolean wrongCut, CardHand cardHand, PlayerType type) {
         super(id);
         this.name = name;
         this.wrongCut = wrongCut;
         this.cardHand = cardHand;
+        this.type = type;
     }
 
     public String getName() {
@@ -85,6 +90,14 @@ public class Player extends Entity {
 
     public void setWrongCut(boolean wrongCut) {
         this.wrongCut = wrongCut;
+    }
+
+    /**
+     * Informa se o jogador é humano ou robô.
+     * @return
+     */
+    public boolean isHuman(){
+        return this.type == PlayerType.HUMAN;
     }
     
 }

--- a/src/main/java/br/ufrn/imd/cambio_imd/models/players/Player.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/models/players/Player.java
@@ -7,15 +7,13 @@ import br.ufrn.imd.cambio_imd.models.cards.Card;
 public class Player extends Entity {
     private String name = "";
     private boolean wrongCut = false;
+    private boolean prohibitedCut = false;
     private CardHand cardHand = new CardHand();
+
+    private int cardIndex = -1;
 
     public Player() {
         super();
-    }
-
-    public Player(String name) {
-        super();
-        this.name = name;
     }
 
     public Player(String name, boolean wrongCut, CardHand cardHand) {
@@ -44,10 +42,6 @@ public class Player extends Entity {
         return wrongCut;
     }
 
-    public void setWrongCut(boolean wrongCut) {
-        this.wrongCut = wrongCut;
-    }
-
     public CardHand getHand() {
         return cardHand;
     }
@@ -63,4 +57,29 @@ public class Player extends Entity {
     public Card removeCard(int index) {
         return cardHand.removeCard(index);
     }
+
+    public boolean isProhibitedCut() {
+        return prohibitedCut;
+    }
+
+    public void setProhibitedCut(boolean prohibitedCut) {
+        this.prohibitedCut = prohibitedCut;
+    }
+
+    public int getCardIndex() {
+        return cardIndex;
+    }
+
+    public void setCardIndex(int cardIndex) {
+        this.cardIndex = cardIndex;
+    }
+
+    public boolean isWrongCut() {
+        return wrongCut;
+    }
+
+    public void setWrongCut(boolean wrongCut) {
+        this.wrongCut = wrongCut;
+    }
+    
 }

--- a/src/main/java/br/ufrn/imd/cambio_imd/observers/IGameAnimationObserver.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/observers/IGameAnimationObserver.java
@@ -1,0 +1,6 @@
+package br.ufrn.imd.cambio_imd.observers;
+
+public interface IGameAnimationObserver {
+    void onCardDrawn();
+    void onCardDiscarded();
+}

--- a/src/main/java/br/ufrn/imd/cambio_imd/observers/IGameStateObserver.java
+++ b/src/main/java/br/ufrn/imd/cambio_imd/observers/IGameStateObserver.java
@@ -1,0 +1,5 @@
+package br.ufrn.imd.cambio_imd.observers;
+
+public interface IGameStateObserver {
+    void onStart();
+}

--- a/src/main/resources/br/ufrn/imd/cambio_imd/views/screen_cambio_lightning_match.fxml
+++ b/src/main/resources/br/ufrn/imd/cambio_imd/views/screen_cambio_lightning_match.fxml
@@ -38,75 +38,58 @@
 <?import javafx.scene.shape.*?>
 <?import javafx.scene.text.*?>
 
-<AnchorPane prefHeight="414.0" prefWidth="701.0" xmlns="http://javafx.com/javafx/11.0.14-internal"
-            xmlns:fx="http://javafx.com/fxml/1" fx:controller="br.ufrn.imd.cambio_imd.controllers.GameController">
+<AnchorPane prefHeight="414.0" prefWidth="701.0" xmlns="http://javafx.com/javafx/11.0.14-internal" xmlns:fx="http://javafx.com/fxml/1" fx:controller="br.ufrn.imd.cambio_imd.controllers.GameController">
     <children>
-        <Pane layoutX="128.0" layoutY="34.0" prefHeight="173.0" prefWidth="448.0">
+        <Pane layoutX="128.0" layoutY="34.0" prefHeight="173.0" prefWidth="448.0" fx:id="pilesPane">
             <children>
-                <ImageView fitHeight="150.0" fitWidth="99.0" layoutX="175.0" layoutY="12.0" pickOnBounds="true"
-                           preserveRatio="true">
-                    <image>
-                        <Image url="@assets/cards/clubKing.png"/>
-                    </image>
+                <ImageView fx:id="discardPileImage" fitHeight="150.0" fitWidth="99.0" layoutX="175.0" layoutY="12.0" pickOnBounds="true" preserveRatio="true">
                 </ImageView>
-                <ImageView fitHeight="80.0" fitWidth="57.0" layoutX="302.0" layoutY="47.0" pickOnBounds="true"
-                           preserveRatio="true">
+                <ImageView fx:id="drawPileImage" fitHeight="80.0" fitWidth="57.0" layoutX="302.0" layoutY="47.0" pickOnBounds="true" preserveRatio="true">
                     <image>
-                        <Image url="@assets/img/cards/redBack.png"/>
+                        <Image url="@assets/img/cards/redBack.png" />
                     </image>
                 </ImageView>
             </children>
         </Pane>
         <Pane layoutX="19.0" layoutY="221.0" prefHeight="182.0" prefWidth="665.0">
             <children>
-                <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#1f93ff00" height="196.0" layoutX="7.0" layoutY="6.0"
-                           smooth="false" stroke="#aeaeae" strokeLineCap="ROUND" strokeLineJoin="ROUND"
-                           strokeType="OUTSIDE" width="651.0"/>
-                <GridPane hgap="10.0" layoutX="14.0" layoutY="60.0" prefHeight="111.0" prefWidth="433.0" vgap="12.0"
-                          fx:id="playerHandGridPane">
+                <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#1f93ff00" height="196.0" layoutX="7.0" layoutY="6.0" smooth="false" stroke="#aeaeae" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeType="OUTSIDE" width="651.0" />
+                <GridPane fx:id="playerHandGridPane" hgap="10.0" layoutX="14.0" layoutY="60.0" prefHeight="111.0" prefWidth="433.0" vgap="12.0">
                     <columnConstraints>
-                        <ColumnConstraints halignment="CENTER" hgrow="ALWAYS"/>
-                        <ColumnConstraints halignment="CENTER" hgrow="ALWAYS"/>
-                        <ColumnConstraints halignment="CENTER" hgrow="ALWAYS"/>
-                        <ColumnConstraints halignment="CENTER" hgrow="ALWAYS"/>
-                        <ColumnConstraints halignment="CENTER" hgrow="ALWAYS"/>
+                        <ColumnConstraints halignment="CENTER" hgrow="ALWAYS" />
+                        <ColumnConstraints halignment="CENTER" hgrow="ALWAYS" />
+                        <ColumnConstraints halignment="CENTER" hgrow="ALWAYS" />
+                        <ColumnConstraints halignment="CENTER" hgrow="ALWAYS" />
+                        <ColumnConstraints halignment="CENTER" hgrow="ALWAYS" />
                     </columnConstraints>
                     <rowConstraints>
-                        <RowConstraints vgrow="ALWAYS"/>
-                        <RowConstraints vgrow="ALWAYS"/>
+                        <RowConstraints vgrow="ALWAYS" />
+                        <RowConstraints vgrow="ALWAYS" />
                     </rowConstraints>
                 </GridPane>
                 <Pane layoutX="457.0" layoutY="13.0" prefHeight="158.0" prefWidth="193.0">
                     <children>
-                        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#1c1c1c8a" height="156.0" stroke="BLACK"
-                                   strokeDashOffset="2.0" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="0.0"
-                                   width="193.0"/>
-                        <Text fill="WHITE" fontSmoothingType="LCD" layoutX="73.0" layoutY="19.0" stroke="#eee0e0"
-                              strokeLineCap="ROUND" strokeType="OUTSIDE" strokeWidth="0.0" text="Jogador"
-                              textAlignment="CENTER">
+                        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#1c1c1c8a" height="156.0" stroke="BLACK" strokeDashOffset="2.0" strokeLineCap="ROUND" strokeLineJoin="ROUND" strokeWidth="0.0" width="193.0" />
+                        <Text fill="WHITE" fontSmoothingType="LCD" layoutX="73.0" layoutY="19.0" stroke="#eee0e0" strokeLineCap="ROUND" strokeType="OUTSIDE" strokeWidth="0.0" text="Jogador" textAlignment="CENTER">
                             <font>
-                                <Font name="Droid Sans Bold" size="13.0"/>
+                                <Font name="Droid Sans Bold" size="13.0" />
                             </font>
                         </Text>
-                        <Text fill="WHITE" fontSmoothingType="LCD" layoutX="78.0" layoutY="76.0" stroke="#eee0e0"
-                              strokeLineCap="ROUND" strokeType="OUTSIDE" strokeWidth="0.0" text="Ações"
-                              textAlignment="CENTER">
+                        <Text fill="WHITE" fontSmoothingType="LCD" layoutX="78.0" layoutY="76.0" stroke="#eee0e0" strokeLineCap="ROUND" strokeType="OUTSIDE" strokeWidth="0.0" text="Ações" textAlignment="CENTER">
                             <font>
-                                <Font name="Droid Sans Bold" size="13.0"/>
+                                <Font name="Droid Sans Bold" size="13.0" />
                             </font>
                         </Text>
-                        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="WHITE" height="26.0" layoutX="13.0"
-                                   layoutY="29.0" stroke="#979797" strokeType="INSIDE" width="167.0"/>
-                        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="WHITE" height="70.0" layoutX="14.0"
-                                   layoutY="79.0" stroke="#979797" strokeType="INSIDE" width="167.0"/>
+                        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="WHITE" height="26.0" layoutX="13.0" layoutY="29.0" stroke="#979797" strokeType="INSIDE" width="167.0" />
+                        <Rectangle arcHeight="5.0" arcWidth="5.0" fill="WHITE" height="70.0" layoutX="14.0" layoutY="79.0" stroke="#979797" strokeType="INSIDE" width="167.0" />
                     </children>
                 </Pane>
             </children>
         </Pane>
-        <VBox alignment="CENTER" layoutX="539.0" layoutY="44.0" prefHeight="208.0" prefWidth="117.0"/>
+        <VBox alignment="CENTER" layoutX="539.0" layoutY="44.0" prefHeight="208.0" prefWidth="117.0" />
         <VBox layoutX="24.0" layoutY="46.0" prefHeight="149.0" prefWidth="194.0">
             <children>
-                <TextArea fx:id="messageBox" prefHeight="200.0" prefWidth="200.0" editable="false"/>
+                <TextArea fx:id="messageBox" editable="false" prefHeight="200.0" prefWidth="200.0" />
             </children>
         </VBox>
     </children>

--- a/src/main/resources/br/ufrn/imd/cambio_imd/views/screen_cambio_lightning_match.fxml
+++ b/src/main/resources/br/ufrn/imd/cambio_imd/views/screen_cambio_lightning_match.fxml
@@ -75,49 +75,6 @@
                         <RowConstraints vgrow="ALWAYS"/>
                         <RowConstraints vgrow="ALWAYS"/>
                     </rowConstraints>
-                    <!--<columnConstraints>
-                       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                       <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                    </columnConstraints>
-                    <rowConstraints>
-                       <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                    </rowConstraints>
-                    <children>
-                       <ImageView fitHeight="102.0" fitWidth="78.0" pickOnBounds="true" preserveRatio="true">
-                          <image>
-                             <Image url="@assets/cards/blueBack.png" />
-                          </image>
-                       </ImageView>
-                       <ImageView fitHeight="102.0" fitWidth="78.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="1">
-                          <image>
-                             <Image url="@assets/cards/blueBack.png" />
-                          </image>
-                       </ImageView>
-                       <ImageView fitHeight="102.0" fitWidth="78.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="2">
-                          <image>
-                             <Image url="@assets/cards/blueBack.png" />
-                          </image>
-                       </ImageView>
-                       <ImageView fitHeight="102.0" fitWidth="78.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="3">
-                          <image>
-                             <Image url="@assets/cards/blueBack.png" />
-                          </image>
-                       </ImageView>
-                       <ImageView fitHeight="102.0" fitWidth="78.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="4">
-                          <image>
-                             <Image url="@assets/cards/blueBack.png" />
-                          </image>
-                       </ImageView>
-                       <ImageView fitHeight="102.0" fitWidth="78.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="5">
-                          <image>
-                             <Image url="@assets/cards/blueBack.png" />
-                          </image>
-                       </ImageView>
-                    </children> !-->
                 </GridPane>
                 <Pane layoutX="457.0" layoutY="13.0" prefHeight="158.0" prefWidth="193.0">
                     <children>


### PR DESCRIPTION
Implementada ação do jogador jogar uma carta e, por consequência, retirar uma carta do baralho de reposição.

Foram introduzidos alguns observadores para uma renderização mais desacoplada entre as camadas. Por exemplo, agora não é necessário acessar o Controller dentro do Manager para iniciar a renderização do jogo (como estava antes), basta executar o método `notifyStartGame`, o qual "contém" o código injetado pelo Controller para renderizar o jogo.